### PR TITLE
feat: add placeholder when images are loading

### DIFF
--- a/frontend/src/components/Recipes/RecipeCard.tsx
+++ b/frontend/src/components/Recipes/RecipeCard.tsx
@@ -13,7 +13,7 @@ export default function RecipeCard({ recipe, noLink }: RecipeCardProps) {
     const { cuisines, diets, difficulties } = useRecipesContext()
     const [isLoading, setIsLoading] = useState(true)
 
-    const fullImageUrl = `http://localhost:8080${image}`
+    const fullImageUrl = `${import.meta.env.VITE_API_ENDPOINT}${image}`
 
     const loadingImage = isLoading ? (
         <div className="absolute inset-0 aspect-square h-full w-full animate-pulse rounded-md bg-gray-200" />

--- a/frontend/src/components/Recipes/RecipeCard.tsx
+++ b/frontend/src/components/Recipes/RecipeCard.tsx
@@ -21,7 +21,10 @@ export default function RecipeCard({ recipe, noLink }: RecipeCardProps) {
 
     return (
         <Link to={`/recipes/${id}`}>
-            <article className="flex flex-wrap overflow-hidden rounded-lg bg-white p-2 shadow transition hover:shadow-md">
+            <article
+                data-clickable={!noLink}
+                className="flex select-text flex-wrap overflow-hidden rounded-lg bg-white p-2 shadow transition hover:shadow-md data-[clickable=true]:hover:scale-[1.01] data-[clickable=true]:hover:opacity-80"
+            >
                 <figure className="relative h-full w-full sm:max-w-64">
                     <>
                         {loadingImage}
@@ -43,11 +46,6 @@ export default function RecipeCard({ recipe, noLink }: RecipeCardProps) {
                         <p>Diet: {diets[Number(dietId)]}</p>
                         <p>Difficulty: {difficulties[Number(difficultyId)]}</p>
                     </section>
-                    {!noLink ? (
-                        <button className="mt-4 w-full rounded-md bg-red-500 py-2 text-white">
-                            View Options
-                        </button>
-                    ) : null}
                 </div>
             </article>
         </Link>

--- a/frontend/src/components/Recipes/RecipeCard.tsx
+++ b/frontend/src/components/Recipes/RecipeCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router'
 import { Recipe } from '../../api/recipe'
 import { useRecipesContext } from '../../context/recipes-context'
+import { useState } from 'react'
 
 type RecipeCardProps = {
     recipe: Recipe
@@ -10,18 +11,30 @@ type RecipeCardProps = {
 export default function RecipeCard({ recipe, noLink }: RecipeCardProps) {
     const { name, image, cuisineId, dietId, difficultyId, id } = recipe
     const { cuisines, diets, difficulties } = useRecipesContext()
+    const [isLoading, setIsLoading] = useState(true)
+
+    const fullImageUrl = `http://localhost:8080${image}`
+
+    const loadingImage = isLoading ? (
+        <div className="absolute inset-0 aspect-square h-full w-full animate-pulse rounded-md bg-gray-200" />
+    ) : null
 
     return (
         <Link to={`/recipes/${id}`}>
             <article className="flex flex-wrap overflow-hidden rounded-lg bg-white p-2 shadow transition hover:shadow-md">
                 <figure className="relative h-full w-full sm:max-w-64">
-                    <img
-                        src={`http://localhost:8080${image}`}
-                        alt={name}
-                        height={64}
-                        width={64}
-                        className="aspect-square h-full w-full rounded-md object-cover"
-                    />
+                    <>
+                        {loadingImage}
+                        <img
+                            src={fullImageUrl}
+                            alt={name}
+                            height={64}
+                            width={64}
+                            className="aspect-square h-full w-full rounded-md object-cover aria-busy:opacity-0"
+                            onLoad={() => setIsLoading(false)}
+                            aria-busy={isLoading}
+                        />
+                    </>
                 </figure>
                 <div className="flex flex-1 flex-col justify-between px-2">
                     <section>


### PR DESCRIPTION
To improve image loading while having bad internet connection I put the actual image's opacity to 0.

Meanwhile there's a skeleton loader on top that will be removed when the actual image load.

When the actual image load -> the opacity goes back to normal and the skeleton loader is removed
